### PR TITLE
Harden formatting-style wire format against minified enum fields

### DIFF
--- a/tooling/language-server-protocol/src/core/KsonSettings.ts
+++ b/tooling/language-server-protocol/src/core/KsonSettings.ts
@@ -1,5 +1,6 @@
 import {LSPAny} from "vscode-languageserver";
 import {FormattingStyle} from "kson";
+import {formattingStyleFromId} from "./formattingStyle.js";
 
 /**
  * Configuration settings for the Kson language server.
@@ -24,26 +25,11 @@ export interface KsonSettings {
  * namespace key.
  */
 export function ksonSettingsWithDefaults(settings?: LSPAny): Required<KsonSettings> {
-    // Create FormattingStyle based on the provided settings
-    let formatStyle: FormattingStyle
-    if (settings?.format?.formattingStyle) {
-        // Map lowercase string to uppercase enum value exhaustively
-        const style = settings.format.formattingStyle.toLowerCase();
-        switch (style) {
-            case 'plain':
-                formatStyle = FormattingStyle.PLAIN;
-                break;
-            case 'delimited':
-                formatStyle = FormattingStyle.DELIMITED;
-                break;
-            default:
-                // Default to PLAIN for any unrecognized value
-                formatStyle = FormattingStyle.PLAIN;
-                break;
-        }
-    } else {
-        formatStyle = FormattingStyle.PLAIN;
-    }
+    // Map the configured style string to the FormattingStyle enum, defaulting to
+    // PLAIN when absent/unrecognized. The VS Code config enum only surfaces
+    // "plain"/"delimited", but this shares the command path's mapper, so a
+    // hand-edited settings.json value of "compact"/"classic" is also honored.
+    const formatStyle: FormattingStyle = formattingStyleFromId(settings?.format?.formattingStyle);
 
     // CodeLens enabled by default
     const codeLensEnabled = settings?.codeLens?.enable !== false;

--- a/tooling/language-server-protocol/src/core/commands/CommandExecutor.base.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandExecutor.base.ts
@@ -8,6 +8,7 @@ import {FormattingService} from '../features/FormattingService.js';
 import {CommandType} from './CommandType.js';
 import {CommandParameters, isValidCommand} from './CommandParameters.js';
 import {FormatOptions, IndentType} from 'kson';
+import {formattingStyleFromId} from '../formattingStyle.js';
 import {KsonDocument} from "../document/KsonDocument.js";
 
 /**
@@ -66,7 +67,7 @@ export abstract class CommandExecutorBase {
 
                 return this.executeFormat(commandArgs.documentUri, document, new FormatOptions(
                     indentType,
-                    formatArgs.formattingStyle,
+                    formattingStyleFromId(formatArgs.formattingStyle),
                 ));
             }
             case CommandType.ASSOCIATE_SCHEMA: {

--- a/tooling/language-server-protocol/src/core/commands/CommandParameters.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandParameters.ts
@@ -1,6 +1,6 @@
 import { CommandType } from './CommandType.js';
 import { Command } from 'vscode-languageserver';
-import { FormattingStyle } from 'kson';
+import { FormattingStyleId } from '../formattingStyle.js';
 
 /**
  * Type-safe mapping of command types to their expected parameter structures
@@ -8,26 +8,27 @@ import { FormattingStyle } from 'kson';
 export interface CommandParameters {
     [CommandType.PLAIN_FORMAT ]: {
         documentUri: string;
-        formattingStyle: FormattingStyle;
+        // Carried as the style id (lowercase enum name); the server maps it via formattingStyleFromId.
+        formattingStyle: FormattingStyleId;
         // Indentation is injected by the client middleware from the active editor.
         insertSpaces?: boolean;
         tabSize?: number;
     };
     [CommandType.COMPACT_FORMAT ]: {
         documentUri: string;
-        formattingStyle: FormattingStyle;
+        formattingStyle: FormattingStyleId;
         insertSpaces?: boolean;
         tabSize?: number;
     };
     [CommandType.DELIMITED_FORMAT]: {
         documentUri: string;
-        formattingStyle: FormattingStyle;
+        formattingStyle: FormattingStyleId;
         insertSpaces?: boolean;
         tabSize?: number;
     };
     [CommandType.CLASSIC_FORMAT]: {
         documentUri: string;
-        formattingStyle: FormattingStyle;
+        formattingStyle: FormattingStyleId;
         insertSpaces?: boolean;
         tabSize?: number;
     };

--- a/tooling/language-server-protocol/src/core/features/CodeLensService.ts
+++ b/tooling/language-server-protocol/src/core/features/CodeLensService.ts
@@ -3,6 +3,7 @@ import { KsonDocument } from '../document/KsonDocument.js';
 import { CommandType } from '../commands/CommandType.js';
 import { createTypedCommand } from '../commands/CommandParameters.js';
 import { FormattingStyle } from 'kson';
+import { formattingStyleId } from '../formattingStyle.js';
 
 /**
  * Service responsible for providing code lenses for Kson documents
@@ -13,28 +14,32 @@ export class CodeLensService {
      * Get code lenses for a Kson document.
     */
     getCodeLenses(document: KsonDocument): CodeLens[] {
+        const plainId = formattingStyleId(FormattingStyle.PLAIN);
         const formatCommand = createTypedCommand(
             CommandType.PLAIN_FORMAT,
-            'plain',
-            { documentUri: document.uri, formattingStyle: FormattingStyle.PLAIN}
+            plainId,
+            { documentUri: document.uri, formattingStyle: plainId }
         );
 
+        const delimitedId = formattingStyleId(FormattingStyle.DELIMITED);
         const delimitedFormatCommand = createTypedCommand(
             CommandType.DELIMITED_FORMAT,
-            'delimited',
-            { documentUri: document.uri, formattingStyle: FormattingStyle.DELIMITED }
+            delimitedId,
+            { documentUri: document.uri, formattingStyle: delimitedId }
         );
 
+        const compactId = formattingStyleId(FormattingStyle.COMPACT);
         const compactFormatCommand = createTypedCommand(
             CommandType.COMPACT_FORMAT,
-            'compact',
-            { documentUri: document.uri, formattingStyle: FormattingStyle.COMPACT }
+            compactId,
+            { documentUri: document.uri, formattingStyle: compactId }
         );
 
+        const classicId = formattingStyleId(FormattingStyle.CLASSIC);
         const classicFormatCommand = createTypedCommand(
             CommandType.CLASSIC_FORMAT,
-            'classic',
-            { documentUri: document.uri, formattingStyle: FormattingStyle.CLASSIC }
+            classicId,
+            { documentUri: document.uri, formattingStyle: classicId }
         );
 
         // Place both lenses at the start of the document

--- a/tooling/language-server-protocol/src/core/formattingStyle.ts
+++ b/tooling/language-server-protocol/src/core/formattingStyle.ts
@@ -1,0 +1,32 @@
+import {FormattingStyle} from 'kson';
+
+/**
+ * Wire/display id for a formatting style: the Kotlin enum's stable name lowercased
+ * ("plain", "delimited", ...), rather than its minified internal fields. Derived
+ * directly from {@link FormattingStyle} so it can never drift from the enum's own
+ * set of names, and matches the lowercase values the VS Code config surfaces.
+ */
+export type FormattingStyleId = Lowercase<FormattingStyle['name']>;
+
+/**
+ * The wire/display id for a {@link FormattingStyle} — its lowercased enum name.
+ */
+export function formattingStyleId(style: FormattingStyle): FormattingStyleId {
+    return style.name.toLowerCase() as FormattingStyleId;
+}
+
+/**
+ * Resolve a style id back to the {@link FormattingStyle} enum via its canonical
+ * {@link FormattingStyle.valueOf}. Case-insensitive and defaults to
+ * {@link FormattingStyle.PLAIN} for anything absent or unrecognized.
+ */
+export function formattingStyleFromId(id?: string): FormattingStyle {
+    if (!id) {
+        return FormattingStyle.PLAIN;
+    }
+    try {
+        return FormattingStyle.valueOf(id.toUpperCase());
+    } catch {
+        return FormattingStyle.PLAIN;
+    }
+}

--- a/tooling/language-server-protocol/src/test/core/commands/CommandExecutor.test.ts
+++ b/tooling/language-server-protocol/src/test/core/commands/CommandExecutor.test.ts
@@ -13,6 +13,7 @@ import {
 } from "vscode-languageserver";
 import {CommandType, toWireCommandId} from "../../../core/commands/CommandType";
 import {FormattingStyle} from "kson";
+import {FormattingStyleId, formattingStyleId} from "../../../core/formattingStyle";
 import {RemoteWorkspace} from "vscode-languageserver/lib/common/server";
 import {createCommandExecutor} from "../../../core/commands/createCommandExecutor.node.js";
 
@@ -76,7 +77,7 @@ function buildWorkspaceEdit(uri: string, replaceRange: Range, newText: string): 
     };
 }
 
-function buildCommandParams(command: CommandType, uri: string, style: FormattingStyle): ExecuteCommandParams {
+function buildCommandParams(command: CommandType, uri: string, style: FormattingStyleId): ExecuteCommandParams {
     return {
         command: toWireCommandId(command, TEST_DISTRIBUTION_ID),
         arguments: [{ documentUri: uri, formattingStyle: style }]
@@ -125,7 +126,7 @@ describe('KSON Command Executor', () => {
         const expected = buildWorkspaceEdit(TEST_URI,
             Range.create(0, 0, 0, 10)
             , 'x: 1');
-        const commandParams = buildCommandParams(CommandType.PLAIN_FORMAT, TEST_URI, FormattingStyle.PLAIN);
+        const commandParams = buildCommandParams(CommandType.PLAIN_FORMAT, TEST_URI, formattingStyleId(FormattingStyle.PLAIN));
         
         await executeAndAssertCommand(content, expected, commandParams);
     });
@@ -138,7 +139,7 @@ describe('KSON Command Executor', () => {
             '}'
         ].join('\n');
         const expected = buildWorkspaceEdit(TEST_URI, Range.create(0, 0, 0, 10), expectedContent);
-        const commandParams = buildCommandParams(CommandType.DELIMITED_FORMAT, TEST_URI, FormattingStyle.DELIMITED);
+        const commandParams = buildCommandParams(CommandType.DELIMITED_FORMAT, TEST_URI, formattingStyleId(FormattingStyle.DELIMITED));
         
         await executeAndAssertCommand(content, expected, commandParams);
     });
@@ -146,7 +147,7 @@ describe('KSON Command Executor', () => {
     it('should execute compact formatting', async () => {
         const content = '{"x" : 1, "y" : 2}';
         const expected = buildWorkspaceEdit(TEST_URI, Range.create(0, 0, 0, 18), 'x:1 y:2');
-        const commandParams = buildCommandParams(CommandType.COMPACT_FORMAT, TEST_URI, FormattingStyle.COMPACT);
+        const commandParams = buildCommandParams(CommandType.COMPACT_FORMAT, TEST_URI, formattingStyleId(FormattingStyle.COMPACT));
         
         await executeAndAssertCommand(content, expected, commandParams);
     });
@@ -160,7 +161,7 @@ describe('KSON Command Executor', () => {
             '}'
         ].join('\n');
         const expected = buildWorkspaceEdit(TEST_URI, Range.create(0, 0, 0, 18), expectedContent);
-        const commandParams = buildCommandParams(CommandType.CLASSIC_FORMAT, TEST_URI, FormattingStyle.CLASSIC);
+        const commandParams = buildCommandParams(CommandType.CLASSIC_FORMAT, TEST_URI, formattingStyleId(FormattingStyle.CLASSIC));
 
         await executeAndAssertCommand(content, expected, commandParams);
     });

--- a/tooling/language-server-protocol/src/test/core/features/CodeLensService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/CodeLensService.test.ts
@@ -2,7 +2,8 @@ import {CodeLensService} from '../../../core/features/CodeLensService.js';
 import {CommandType} from '../../../core/commands/CommandType.js';
 import {describe, it} from 'mocha';
 import assert from 'assert';
-import {FormattingStyle} from 'kson'
+import {FormattingStyle} from 'kson';
+import {formattingStyleId} from '../../../core/formattingStyle.js';
 import {createKsonDocument, TEST_URI} from '../../TestHelpers.js';
 import {TextDocument} from 'vscode-languageserver-textdocument';
 import {KsonDocument, parseTextDocument} from '../../../core/document/KsonDocument.js';
@@ -44,10 +45,10 @@ describe('CodeLensService', () => {
         const document = createKsonDocument('key: value');
         const lenses = service.getCodeLenses(document);
 
-        assert.strictEqual(lenses[0].command?.arguments?.[0].formattingStyle, FormattingStyle.PLAIN);
-        assert.strictEqual(lenses[1].command?.arguments?.[0].formattingStyle, FormattingStyle.DELIMITED);
-        assert.strictEqual(lenses[2].command?.arguments?.[0].formattingStyle, FormattingStyle.CLASSIC);
-        assert.strictEqual(lenses[3].command?.arguments?.[0].formattingStyle, FormattingStyle.COMPACT);
+        assert.strictEqual(lenses[0].command?.arguments?.[0].formattingStyle, formattingStyleId(FormattingStyle.PLAIN));
+        assert.strictEqual(lenses[1].command?.arguments?.[0].formattingStyle, formattingStyleId(FormattingStyle.DELIMITED));
+        assert.strictEqual(lenses[2].command?.arguments?.[0].formattingStyle, formattingStyleId(FormattingStyle.CLASSIC));
+        assert.strictEqual(lenses[3].command?.arguments?.[0].formattingStyle, formattingStyleId(FormattingStyle.COMPACT));
     });
 
     it('should place all lenses at line 0, character 0', () => {


### PR DESCRIPTION
Format commands carried `formattingStyle` as a raw kson FormattingStyle enum, which serialized over JSON-RPC as its Kotlin/JS internal fields (e.g. {"w1_1":"PLAIN","x1_1":0}) and was passed straight into FormatOptions. That only worked because the same server build round-tripped the object, and it broke for any client constructing the arg itself — a literal "plain" threw NoWhenBranchMatchedException, blocking non-CodeLens triggers.

Introduce core/formattingStyle.ts as the single source of truth:
  - FormattingStyleId = Lowercase<FormattingStyle['name']> (type derived from the enum, no hand-written literals)
  - formattingStyleId(style)  -> the enum's lowercased name ("plain", ...)
  - formattingStyleFromId(id)  -> FormattingStyle via valueOf, case- insensitive, defaulting to PLAIN

Commands now carry the string id; CommandExecutor and KsonSettings both resolve it through formattingStyleFromId, replacing KsonSettings' own two-case switch. CodeLensService derives both the lens title and the wire value from formattingStyleId, so config and commands share one lowercase convention and nothing depends on minified fields.

Note: the command wire value changes from the serialized enum object to a lowercase id string (internal client<->server protocol; not user-visible). Config now also honors hand-edited "compact"/"classic" values.